### PR TITLE
[pigeon] [cpp] Write FlutterError utilities for HostAPI

### DIFF
--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 12.1.2
+
+* Fixes an incorrect use of `extends` for Dart 3 compatibility.
+* Updates minimum supported SDK version to Flutter 3.10/Dart 3.0.
+
 ## 12.1.1
 
 - Retains query parameters during refresh and first redirect.
@@ -75,7 +80,7 @@
 
 ## 10.1.1
 
-- Fixes mapping from `Page` to `RouteMatch`s. 
+- Fixes mapping from `Page` to `RouteMatch`s.
 - Updates minimum supported SDK version to Flutter 3.7/Dart 2.19.
 
 ## 10.1.0

--- a/packages/go_router/example/pubspec.yaml
+++ b/packages/go_router/example/pubspec.yaml
@@ -4,8 +4,8 @@ version: 3.0.1
 publish_to: none
 
 environment:
-  sdk: ">=2.19.0 <4.0.0"
-  flutter: ">=3.7.0"
+  sdk: ">=3.0.0 <4.0.0"
+  flutter: ">=3.10.0"
 
 dependencies:
   adaptive_navigation: ^0.0.4

--- a/packages/go_router/lib/src/delegate.dart
+++ b/packages/go_router/lib/src/delegate.dart
@@ -247,7 +247,7 @@ class GoRouterDelegate extends RouterDelegate<RouteMatchList>
 /// The iterator starts with the navigator that hosts the top-most route. This
 /// navigator may not be the inner-most navigator if the top-most route is a
 /// pageless route, such as a dialog or bottom sheet.
-class _NavigatorStateIterator extends Iterator<NavigatorState> {
+class _NavigatorStateIterator implements Iterator<NavigatorState> {
   _NavigatorStateIterator(this.matchList, this.root)
       : index = matchList.matches.length - 1;
 

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -1,13 +1,13 @@
 name: go_router
 description: A declarative router for Flutter based on Navigation 2 supporting
   deep linking, data-driven routes and more
-version: 12.1.1
+version: 12.1.2
 repository: https://github.com/flutter/packages/tree/main/packages/go_router
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router%22
 
 environment:
-  sdk: ">=2.19.0 <4.0.0"
-  flutter: ">=3.7.0"
+  sdk: ">=3.0.0 <4.0.0"
+  flutter: ">=3.10.0"
 
 dependencies:
   collection: ^1.15.0

--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 13.1.2
+
+* Adds compatibilty with `analyzer` 6.x.
+
 ## 13.1.1
 
 * [kotlin] Removes unnecessary `;`s in generated code.

--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 13.1.2
+
+* [cpp] Fix C++ generator skipping FlutterError if no FlutterAPI is defined.
+
+
 ## 13.1.1
 
 * [kotlin] Removes unnecessary `;`s in generated code.

--- a/packages/pigeon/lib/cpp_generator.dart
+++ b/packages/pigeon/lib/cpp_generator.dart
@@ -196,8 +196,13 @@ class CppHeaderGenerator extends StructuredGenerator<CppOptions> {
     final bool hasFlutterApi = root.apis.any((Api api) =>
         api.methods.isNotEmpty && api.location == ApiLocation.flutter);
 
-    if (hasHostApi) {
+    // Always write?
+    if (hasFlutterApi || hasHostApi) {
       _writeErrorOr(indent, friends: root.apis.map((Api api) => api.name));
+    }
+
+    if (hasHostApi) {
+      // Nothing yet
     }
     if (hasFlutterApi) {
       // Nothing yet.

--- a/packages/pigeon/lib/generator_tools.dart
+++ b/packages/pigeon/lib/generator_tools.dart
@@ -13,7 +13,7 @@ import 'ast.dart';
 /// The current version of pigeon.
 ///
 /// This must match the version in pubspec.yaml.
-const String pigeonVersion = '13.1.1';
+const String pigeonVersion = '13.1.2';
 
 /// Read all the content from [stdin] to a String.
 String readStdin() {

--- a/packages/pigeon/pubspec.yaml
+++ b/packages/pigeon/pubspec.yaml
@@ -2,13 +2,13 @@ name: pigeon
 description: Code generator tool to make communication between Flutter and the host platform type-safe and easier.
 repository: https://github.com/flutter/packages/tree/main/packages/pigeon
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3Apigeon
-version: 13.1.1 # This must match the version in lib/generator_tools.dart
+version: 13.1.2 # This must match the version in lib/generator_tools.dart
 
 environment:
   sdk: ">=2.19.0 <4.0.0"
 
 dependencies:
-  analyzer: "^5.13.0"
+  analyzer: ">=5.13.0 <7.0.0"
   args: ^2.1.0
   collection: ^1.15.0
   meta: ^1.7.0

--- a/packages/pigeon/pubspec.yaml
+++ b/packages/pigeon/pubspec.yaml
@@ -2,7 +2,7 @@ name: pigeon
 description: Code generator tool to make communication between Flutter and the host platform type-safe and easier.
 repository: https://github.com/flutter/packages/tree/main/packages/pigeon
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3Apigeon
-version: 13.1.1 # This must match the version in lib/generator_tools.dart
+version: 13.1.2 # This must match the version in lib/generator_tools.dart
 
 environment:
   sdk: ">=2.19.0 <4.0.0"

--- a/packages/plugin_platform_interface/CHANGELOG.md
+++ b/packages/plugin_platform_interface/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.1.7
+
+* Changes `MockPlatformInterfaceMixin` to a `mixin class` for better
+  compatibility with projects that have a minumum Dart SDK version of 3.0.
+* Updates minimum supported SDK version to Dart 3.0.
+
 ## 2.1.6
 
 * Adds pub topics to package metadata.

--- a/packages/plugin_platform_interface/lib/plugin_platform_interface.dart
+++ b/packages/plugin_platform_interface/lib/plugin_platform_interface.dart
@@ -126,4 +126,4 @@ abstract class PlatformInterface {
 ///    implements UrlLauncherPlatform {}
 /// ```
 @visibleForTesting
-abstract class MockPlatformInterfaceMixin implements PlatformInterface {}
+abstract mixin class MockPlatformInterfaceMixin implements PlatformInterface {}

--- a/packages/plugin_platform_interface/pubspec.yaml
+++ b/packages/plugin_platform_interface/pubspec.yaml
@@ -15,10 +15,10 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 # be done when absolutely necessary and after the ecosystem has already migrated to 2.X.Y version
 # that is forward compatible with 3.0.0 (ideally the ecosystem have migrated to depend on:
 # `plugin_platform_interface: >=2.X.Y <4.0.0`).
-version: 2.1.6
+version: 2.1.7
 
 environment:
-  sdk: ">=2.19.0 <4.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   meta: ^1.3.0


### PR DESCRIPTION
It seems that when you have a pigeon configuration as follows
```dart
import 'package:pigeon/pigeon.dart';
@ConfigurePigeon(PigeonOptions(
  dartOut: 'lib/src/pigeon.g.dart',
  dartOptions: DartOptions(),
  cppOptions: CppOptions(namespace: "pigeon", ),
  cppHeaderOut: 'windows/runner/pigeon.g.h',
  cppSourceOut: 'windows/runner/pigeon.g.cpp',
  objcHeaderOut: 'macos/Runner/pigeon.g.h',
  objcSourceOut: 'macos/Runner/pigeon.g.m',
  // Set this to a unique prefix for your plugin or application, per Objective-C naming conventions.
  objcOptions: ObjcOptions(prefix: 'PGN'),
  // copyrightHeader: 'pigeons/copyright.txt',
  dartPackageName: 'desktop_adb_file_browser',
))

@FlutterApi()
abstract class Native2Flutter {
  void onClick(bool forward);
}

// For pigeon bug-testing
// Uncomment to generate FlutterError types 
// @HostApi()
// abstract class Flutter2Native {
//   void random(bool x);
// }
```

I'm not sure why this condition existed in the first place, as it was generating since v10.0.0. Regardless, it breaks compiles on Windows. The HostAPI methods still require FlutterError as shown below, so this clearly is necessary.
```cpp
// Generated class from Pigeon that represents Flutter messages that can be called from C++.
class Native2Flutter {
 public:
  Native2Flutter(flutter::BinaryMessenger* binary_messenger);
  static const flutter::StandardMessageCodec& GetCodec();
  void OnClick(
    bool forward,
    std::function<void(void)>&& on_success,
    std::function<void(const FlutterError&)>&& on_error);

 private:
  flutter::BinaryMessenger* binary_messenger_;
};
```

*List which issues are fixed by this PR. You must list at least one issue.*
- Generate FlutterError and other utilities in the C++ header as previously done (and currently required).

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [ ] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

A few things to mention:
- I was unable to sign the CLA, apparently some server issue or something?
- Running `flutter test` in the `packages/pigeon` directory just spammed a lot of `dart:mirror not supported` errors.
- I didn't file a bug report for this issue as noted in the [Tree Hygiene] wiki page, but I can do so if needed (again, small fix so I didn't bother)

Hopefully not a huge issue, but feel free to cherry pick or just manually implement the fix if these issues block the merge.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
